### PR TITLE
[package_info_plus_windows] remove trailing \u0000

### DIFF
--- a/packages/package_info_plus_windows/lib/src/file_version_info.dart
+++ b/packages/package_info_plus_windows/lib/src/file_version_info.dart
@@ -57,7 +57,7 @@ class _FileVersionInfo {
       [_GetUserDefaultLangID(), 1252],
     ];
 
-    var value;
+    String? value;
     final Pointer<IntPtr>? lplpBuffer = calloc<IntPtr>();
     final Pointer<Uint32>? puLen = calloc<Uint32>();
 
@@ -80,7 +80,7 @@ class _FileVersionInfo {
 
     calloc.free(lplpBuffer!);
     calloc.free(puLen!);
-    return value;
+    return value?.replaceFirst(RegExp(r'\u0000$'), '');
   }
 
   static _FileVersionInfoData _getData(String filePath) {


### PR DESCRIPTION
## Description

Each property of `_FileVersionInfo` has a trailing `\u0000` if the property exists. Just removing the empty char before returning value in `getValue`.

## Related Issues
- #182
- #250

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
